### PR TITLE
Fixed typo in animation_delicode_ni_mate_tools.py

### DIFF
--- a/Blender/animation_delicode_ni_mate_tools.py
+++ b/Blender/animation_delicode_ni_mate_tools.py
@@ -263,7 +263,7 @@ class NImateReceiver():
                         print(to_evaluate)
                         print(str(e))
                 elif len(decoded) == 3: #one value
-                    if ob_name == "NI_mate_sync":
+                    if ob_name == "/NI_mate_sync":
                         if sync:
                             self.next_sync = True
                         else:


### PR DESCRIPTION
NI mate is sending data as **"/NI_mate_sync"** but python script is looking for **"NI_mate_sync"**
Fixes #9 'Add rotations' and #8  'reset on stop' not working

**'sync'** is never **'True'** for **"NI_mate_sync"**,
hence the **set_location_func()** and **set_rotation_func()** never being called with the **original_locations** dictionary