### PR TITLE
A few updates to the 2.8 code

### DIFF
--- a/Blender/animation_delicode_ni_mate_tools.py
+++ b/Blender/animation_delicode_ni_mate_tools.py
@@ -392,13 +392,16 @@ class DelicodeNImate(bpy.types.Operator):
         add_rotations = bpy.context.scene.delicode_ni_mate_add_rotations
         reset_locrot = bpy.context.scene.delicode_ni_mate_reset
 
-        if 'NIMate' not in bpy.data.collections:
-            bpy.context.view_layer.active_layer_collection = context.view_layer.layer_collection.children[0]
-            base_collection = bpy.data.collections.new(name="NIMate")
-            bpy.context.scene.collection.children.link(base_collection)
-        else:
-            for ob in bpy.data.collections['NIMate'].objects:
+        collection = bpy.data.collections.get('NIMate')
+
+        if 'NIMate' in bpy.data.collections:
+            for ob in collection.objects:
                 bpy.data.objects.remove(ob, do_unlink=True)
+            bpy.data.collections.remove(collection)
+       
+        bpy.context.view_layer.active_layer_collection = context.view_layer.layer_collection.children[0]
+        base_collection = bpy.data.collections.new(name="NIMate")
+        bpy.context.scene.collection.children.link(base_collection)
     
         self.receiver = NImateReceiver(context.scene.delicode_ni_mate_port, None)
         

--- a/Blender/animation_delicode_ni_mate_tools.py
+++ b/Blender/animation_delicode_ni_mate_tools.py
@@ -476,11 +476,10 @@ def clear_properties():
     scene = bpy.types.Scene
     
     del scene.delicode_ni_mate_port
-    del scene.delicode_ni_mate_quit
-    del scene.delicode_ni_mate_start
     del scene.delicode_ni_mate_add_rotations
     del scene.delicode_ni_mate_reset
     del scene.delicode_ni_mate_create
+    del scene.delicode_ni_mate_start_profile
 
 classes = (
     DelicodeNImate,

--- a/Blender/animation_delicode_ni_mate_tools.py
+++ b/Blender/animation_delicode_ni_mate_tools.py
@@ -68,6 +68,9 @@ def set_location(objects, ob_name, vec, originals):
         ob.name = ob_name
         ob.location = 10*vec
 
+        bpy.data.collections['NIMate'].objects.link(ob)
+        bpy.data.collections[0].objects.unlink(ob)
+
         if(bpy.context.scene.tool_settings.use_keyframe_insert_auto):
             objects[ob_name].keyframe_insert(data_path="location")
 
@@ -388,6 +391,15 @@ class DelicodeNImate(bpy.types.Operator):
         global reset_locrot
         add_rotations = bpy.context.scene.delicode_ni_mate_add_rotations
         reset_locrot = bpy.context.scene.delicode_ni_mate_reset
+
+        if 'NIMate' not in bpy.data.collections:
+            bpy.context.view_layer.active_layer_collection = context.view_layer.layer_collection.children[0]
+            base_collection = bpy.data.collections.new(name="NIMate")
+            bpy.context.scene.collection.children.link(base_collection)
+        else:
+            for ob in bpy.data.collections['NIMate'].objects:
+                bpy.data.objects.remove(ob, do_unlink=True)
+    
         self.receiver = NImateReceiver(context.scene.delicode_ni_mate_port, None)
         
         context.window_manager.modal_handler_add(self)


### PR DESCRIPTION
When the first 2.8 implementation came about there was no set way of creating and manipulating collections. I've revised the code to include an 'NIMate' collection on start so that the plugin doesn't pollute the default scene collection with objects.

This update also removes all the objects on start so that if the user switches types they don't have to delete the created objects manually first.

I also deleted an unused reference that was being called when the plugin was being removed-- seems like it was still from the BGE implementation. 

A few notes: There might be some changes that happen to the blender python api during the 3.0 transition: https://wiki.blender.org/wiki/Reference/Release_Notes/3.0/Python_API

It seems like they're changing 'wiki_url' to 'doc_url' in bl_info. Not sure what else to look out for but that might be something to implement in the future.